### PR TITLE
Add conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ add_premise_gwp()
 
 or
 
-`conda install -c romainsacchi premise_gwp`
+`conda install -c conda-forge premise_gwp`
 


### PR DESCRIPTION
People at our company want to use packages of the [brightway ecosystem](https://github.com/brightway-lca). As we rely heavily on conda-forge I bring all packages we use at our company there and maintain a few feedstocks. I already added your package to [conda-forge](https://conda-forge.org/). If you wish I can also add you as a feedstock maintainer. Otherwise I will happily maintain the recipe.